### PR TITLE
Minor updates

### DIFF
--- a/docs/risk-assessment-guide.md
+++ b/docs/risk-assessment-guide.md
@@ -44,7 +44,7 @@ This also applies to modules that are re-packaged for other native packaging eco
 2. Upstream placement in the [River of CPAN](https://neilb.org/2015/04/20/river-of-cpan.html) — An indication of this can be found on MetaCPAN's reverse dependency list ([example](https://metacpan.org/dist/Test-Simple/requires)).
 3. Bus-factor — How many active developers with indexing permissions exist? You can find this out on MetaCPAN ([example](https://metacpan.org/dist/Test-Simple) in left column).
 4. Advocacy visibility — Is the project (or one of it's reverse dependencies) actively mentioned in social media or common community channels?
-5. Funding options — Does the project offer low-effort ways for users to donate to it?E.g. [Ko-fi](https://ko-fi.com/) or [Paypal](https://www.paypal.com/donate/buttons) donation links, or maybe even ~~[Github Sponsors](https://github.com/sponsors)~~, or ~~[Tidelift](https://tidelift.com/)~~
+5. Funding options — Does the project offer low-effort ways for users to donate to it? E.g. [Ko-fi](https://ko-fi.com/) or [Paypal](https://www.paypal.com/donate/buttons) donation links, or maybe even ~~[Github Sponsors](https://github.com/sponsors)~~, or ~~[Tidelift](https://tidelift.com/)~~
 6. Collaboration metrics — Forum activity; Issue triage and responsiveness; Merge requests.
 
 

--- a/docs/risk-mitigation-guide.md
+++ b/docs/risk-mitigation-guide.md
@@ -26,6 +26,7 @@ Please see our [CPAN Risk Assessment Guide](risk-assessment-guide.md).
 2. Consider availability for assisting when owner is looking for co-maintainer support, via the [NEEDHELP](https://metacpan.org/author/NEEDHELP) facility on PAUSE/CPAN
 3. Consider the availability for hand-off when owner is looking for someone to take over the distribution, via the [HANDOFF](https://metacpan.org/author/HANDOFF) facility on PAUSE/CPAN
 4. Look for funding options for the projects in question
+5. Update the required version for dependencies when included modules implement security fixes
 
 
 ## For CPAN ecosystems themselves, including PAUSE, MetaCPAN and any other supporting systems.


### PR DESCRIPTION
one typo and a added something in mitigation to recommend requiring the new version of a module that has had security fixes.  I wonder if there is a Dist::Zilla plugin to point out when you are including any module version but certain versions have security fixes
