### PR TITLE
add HTML redirect from /cve/ to https://lists.security.metacpan.org/cve-announce/

### DIFF
--- a/cve-announce.md
+++ b/cve-announce.md
@@ -3,4 +3,3 @@ permalink: /cve-announce
 redirect_to:
   - https://lists.security.metacpan.org/cve-announce/
 ---
-[cve-announce](https://lists.security.metacpan.org/cve-announce/)

--- a/cve-announce.md
+++ b/cve-announce.md
@@ -1,0 +1,6 @@
+---
+permalink: /cve-announce
+redirect_to:
+  - https://lists.security.metacpan.org/cve-announce/
+---
+[cve-announce](https://lists.security.metacpan.org/cve-announce/)

--- a/cve-announce/index.html
+++ b/cve-announce/index.html
@@ -1,6 +1,0 @@
-<title>Redirecting to https://lists.security.metacpan.org/cve-announce/</title>
-<meta http-equiv="refresh" content="0; URL=https://lists.security.metacpan.org/cve-announce/">
-<link rel="canonical" href="https://lists.security.metacpan.org/cve-announce/">
-<body>
-	Redirecting to <a href="https://lists.security.metacpan.org/cve-announce/">https://lists.security.metacpan.org/cve-announce/</a> ...
-</body>

--- a/cve-announce/index.html
+++ b/cve-announce/index.html
@@ -1,0 +1,6 @@
+<title>Redirecting to https://lists.security.metacpan.org/cve-announce/</title>
+<meta http-equiv="refresh" content="0; URL=https://lists.security.metacpan.org/cve-announce/">
+<link rel="canonical" href="https://lists.security.metacpan.org/cve-announce/">
+<body>
+	Redirecting to <a href="https://lists.security.metacpan.org/cve-announce/">https://lists.security.metacpan.org/cve-announce/</a> ...
+</body>

--- a/cve.md
+++ b/cve.md
@@ -1,0 +1,5 @@
+---
+permalink: /cve
+redirect_to:
+  - https://lists.security.metacpan.org/cve-announce/
+---


### PR DESCRIPTION
Redirecting /cve/ to lists domain