### PR TITLE
Explicit repository in _config.yml so that jekyll serve still works when changing git remotes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,8 @@ header_pages:
   - docs/README.md
   - presentations/README.md
 
+repository: CPAN-Security/security.metacpan.org
+
 paginate: 4
 paginate_path: "/news/all/page:num"
 


### PR DESCRIPTION
# Changes
If you change git remote, `jekyll serve` no longer works. Doing this change to fix that. 