### PR TITLE
Update cpan-security mailing list address in Pre-Release Disclosure and on index

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you care and would like to make a contribution or join, you are welcome to do
 * Check us out on [Github](https://github.com/CPAN-Security) :octocat:
 * Join us in our [Matrix channel](https://matrix.to/#/#cpansec-discussion:matrix.org), #cpansec-discussion on matrix.org
 * Join us in our [IRC channel](ircs://ssl.irc.perl.org:7062/#cpan-security), #cpan-security on irc.perl.org
-* Send an e-mail to the CPAN Security Group &lt;[cpan-security&#64;perl.org](mailto:cpan-security@perl.org)&gt; 📧
+* Send an e-mail to the CPAN Security Group &lt;[cpan-security&#64;security.metacpan.org](mailto:cpan-security@security.metacpan.org)&gt; 📧
 * Subscribe to [@cpan_security@perl.social](https://perl.social/profile/cpan_security) on the Fediverse :elephant:
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 header_title: CPANSec
 author: CPAN Security Outreach & Information Project
-#email: cpan-security@perl.org
 description: >-
   CPAN Security Group (CPANSec) 🦆
 baseurl: ""

--- a/docs/pre-release-disclosure.md
+++ b/docs/pre-release-disclosure.md
@@ -17,14 +17,14 @@ This includes access to embargoed pre-release vulnerability information provided
 Members need to agree to the following before getting access to information about undisclosed vulnerabilities through private channels:
 
 1. The information that you obtain as part of the pre-release notification is not to be shared with anyone besides;
-   - cpan-security@perl.org members
+   - cpan-security mailing list members
    - The Perl security team
    - The authors or security team of affected packages
    - The sender and recipients of the original notification email 
 
    Information should be kept [[TLP:RED]](https://www.cisa.gov/news-events/news/traffic-light-protocol-tlp-definitions-and-usage) and shared, with the groups listed above, on a need to know basis only.
 
-2. All discussion about the pre-release information is to be handled through private channels such as the cpan-security@perl.org mailing list.
+2. All discussion about the pre-release information is to be handled through private channels such as the cpan-security mailing list.
 This information is not to be discussed on public channels such as IRC, Mastodon, or similar.
 
 3. Patches or PoCs are not to be kept on public GIT or CPAN repos available to anyone else, or similar.
@@ -32,9 +32,9 @@ Testing of patches must be in a staged private environment isolated to your syst
 
 4. The deployment of the patches and/or mitigations for pre-release vulnerabilities is NOT permitted to any system during the embargo, with the exception of CRITICAL vulnerabilities that threaten the integrity of PAUSE, CPAN or MetaCPAN.
 
-Members of CPANSec that needs access to pre-release disclosure information (i.e. members of the cpan-security@perl.org mailing list, VINCE/CC portal, or similar) need to accept these terms by adding their name to "Signatories" below.
+Members of CPANSec that needs access to pre-release disclosure information (i.e. members of the cpan-security mailing list, VINCE/CC portal, or similar) need to accept these terms by adding their name to "Signatories" below.
 
-The CPAN Security Group <[cpan-security@perl.org](cpan-security@perl.org)> (CPANSec)
+The CPAN Security Group <[cpan-security@security.metacpan.org](cpan-security@security.metacpan.org)> (CPANSec)
 
 ------------------
 


### PR DESCRIPTION
This PR updates the mailing list address for CPANSec, and replaces it with a generic "cpan-security mailing list" in the Pre-Release Agreement.

The previous address was cpan-security@perl.org, and the new address is cpan-security@security.metacpan.org

Signatories to the Pre-Release Agreement should also consent to this change in the text. (Cc for review: @andk @thesamesam)