### PR TITLE
Adjust wording

### DIFF
--- a/docs/guides/security-policy-for-authors.md
+++ b/docs/guides/security-policy-for-authors.md
@@ -99,7 +99,7 @@ If your security policy is based on the advice of this document, then
 you should mention that, along with the version:
 
 > This text is based on the CPAN Security Group's Guidelines for Adding
-> a Security Policy to Perl Distributions (version 0.2.1)
+> a Security Policy to Perl Distributions (version 0.2.2)
 > https://security.metacpan.org/docs/guides/security-policy-for-authors.html
 
 #### Links from other module documentation
@@ -329,7 +329,7 @@ The latest version of the Security Policy can be found in the
 [git repository for Foo-Bar](https://example.github.com/foobar).
 
 This text is based on the CPAN Security Group's Guidelines for Adding
-a Security Policy to Perl Distributions (version 0.2.1)
+a Security Policy to Perl Distributions (version 0.2.2)
 https://security.metacpan.org/docs/guides/security-policy-for-authors.html
 
 # How to Report a Security Vulnerability
@@ -431,7 +431,7 @@ Please see the software documentation for further information.
 
 ## License and use of this document
 
-* Version: 0.2.1
+* Version: 0.2.2
 * License: [CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/deed)
 * Copyright: © Robert Rothenberg <rrwo@cpan.org>, Some rights reserved.
 

--- a/docs/guides/security-policy-for-authors.md
+++ b/docs/guides/security-policy-for-authors.md
@@ -131,9 +131,6 @@ For example,
 
 > Security vulnerabilities can be reported by e-mail to the current
 > project maintainer(s) at <foobar@example.com>.
->
-> Please include as many details as possible, including code
-> samples or text cases, so that we can reproduce the issue.
 
 or [\[1\]](#references-and-notes) (Github-Sec-Advisory)
 
@@ -156,11 +153,18 @@ Please ensure that the security contact information is consistent with
 distribution metadata, e.g. in the `META.json` file
 [\[3\]](#references-and-notes) (CPAN-Meta-Spec).
 
-Add note about also copying CPANSec on the notification if help is
-required triaging the issue, or if the issue is being actively
-exploited.  CPANSec provides support to reporters and maintainers in
-assessing the appropriate response, and in case the maintainer(s) are
-unreachable.  For example
+Add a reminder to include details for verifying the bug:
+
+> Please include as many details as possible, including code samples
+> or test cases, so that we can reproduce the issue.  Check that your
+> report does not expose any sensitive data, such as passwords,
+> tokens, or personal information.
+
+We recommend that you add note about also copying CPANSec on the
+notification if help is required triaging the issue, or if the issue
+is being actively exploited.  CPANSec provides support to reporters
+and maintainers in assessing the appropriate response, and in case the
+maintainer(s) are unreachable.  For example
 
 > If you would like any help with triaging the issue, or if the issue
 > is being actively exploited, please copy the report to the CPAN
@@ -334,7 +338,9 @@ Security vulnerabilities can be reported by e-mail to the current
 project maintainers at <foobar@example.com>.
 
 Please include as many details as possible, including code samples
-or test cases, so that we can reproduce the issue.
+or test cases, so that we can reproduce the issue.  Check that your
+report does not expose any sensitive data, such as passwords,
+tokens, or personal information.
 
 If you would like any help with triaging the issue, or if the issue
 is being actively exploited, please copy the report to the CPAN

--- a/docs/report.md
+++ b/docs/report.md
@@ -43,7 +43,6 @@ It's important that you **do not** post information about it on:
 - social media or chat channels, like IRC or Mastodon
 - mailing lists or discussion forums
 
-
 ### Step 1: Prepare a Report
 
 Please provide a detailed description of the steps required to reproduce the vulnerability.
@@ -54,12 +53,20 @@ The following information is required:
 - Proof of concept code, or a description on how to reproduce
 - Logs, code lines, screenshots and other context if relevant
 
+Please ensure any sensitive data such as passwords, authentication tokens, or personal data is not included in the report.
+
 Also consider proposing a date for public disclosure, this is usually 30 days or longer.
 
 
-### Step 2: Contact the Author
+### Step 2: Contact the Maintainer
 
-Send the vulnerability report to the distribution author by email or other private channels.
+Check the distribution for a security policy that advises how to report a security vulnerability.
+It is usually a file called `SECURITY.md`, or there may be a section in the `README` or main module documentation.
+
+If there is no security policy, look in the `README` or main module documentation for an email address of the current maintainer (who may be different from the original author).
+You can also check MetaCPAN to see who uploaded the latest version.
+
+Send the vulnerability report to the distribution maintainer by email or other private channels as outlined in the security policy.
 You can CC our team on [cpan-security@security.metacpan.org](mailto:cpan-security@security.metacpan.org) on the report if you would like us to help in triaging the issue, register CVE identifiers, or for any other reason.
 
 The authors email address is usually available in the documentation, or on their page on [metacpan.org](https://metacpan.org/).


### PR DESCRIPTION
Changes in this branch:
- Move the reminder about including details after the different options for submitting reports.
- Update the reminder to check that details do not include private information.
- Change the wording about copying CPANSec to recommend it.

This also updates the "Report a security issue" with
- Reminder about excluding private information
- Checking for a security policy
