### PR TITLE
CPANSec meeting was postponed two weeks

### DIFF
--- a/meetings/README.md
+++ b/meetings/README.md
@@ -2,7 +2,7 @@
 layout: page
 permalink: /meetings/
 toc: false
-next_meeting_time: February 5th, 2025 16:00 UTC
+next_meeting_time: February 19th, 2025 17:00 UTC
 title: CPANSec meeting details & minutes
 ---
 
@@ -24,7 +24,7 @@ title: CPANSec meeting details & minutes
 * [2025-01-08](cpansec-minutes-2025-01-08.md)
 * [2025-01-22](cpansec-minutes-2025-01-22.md)
 * [2025-02-05](cpansec-minutes-2025-02-05.md)
-
+* [2025-02-19](cpansec-minutes-2025-02-19.md)
 
 ### 2024
 * [2024-01-06](cpansec-minutes-2024-01-06.md)
@@ -36,6 +36,8 @@ title: CPANSec meeting details & minutes
 * [2024-04-10](cpansec-minutes-2024-04-10.md)
 * [2024-05-15](cpansec-minutes-2024-05-15.md)
 * [2024-06-05](cpansec-minutes-2024-06-05.md)
+
+
 * [2024-07-18](cpansec-minutes-2024-07-18.md)
 * [2024-08-01](cpansec-minutes-2024-08-01.md)
 * [2024-08-15](cpansec-minutes-2024-08-15.md)
@@ -48,4 +50,4 @@ title: CPANSec meeting details & minutes
 
 ### Under review
 
-Meeting minutes [currently under review](https://github.com/CPAN-Security/security.metacpan.org/pulls?q=is%3Apr+is%3Aopen+label%3Aminutes) on Github.
+Meeting minutes [currently under review](https://github.com/CPAN-Security/security.metacpan.org/pulls?q=is%3Apr+is%3Aopen+label%3Aminutes) on Github (usually available some days after a meeting).

--- a/meetings/cpansec-minutes-2025-02-05.md
+++ b/meetings/cpansec-minutes-2025-02-05.md
@@ -1,0 +1,25 @@
+---
+layout: page
+toc: true
+meeting_time: 2025-02-05 16:00 UTC
+title: Minutes 2025-02-05
+---
+
+## Meeting Details
+* 2025-02-05 16:00 UTC on #cpansec-discussion on Matrix
+
+## 16:00 UTC – Meeting start
+
+### Attendees, absents & regrets
+*   Attendees
+    * @sjn, @stigtsp
+*   Regrets
+    * @thibaultduponchelle, @robrwo, @timlegge
+
+### Meeting postponed
+* @sjn – Due to low turnout, @stigtsp and @sjn decided to postpone the meeting two weeks
+
+### Next meeting date, time and location
+*   Next meeting is Wednesday 2025-02-19 @ 17:00UTC in #cpansec-discussion on Matrix (18:00 Europe/Amsterdam)
+
+## 17:29 UTC – Meeting end


### PR DESCRIPTION
Only @stigtsp and @sjn attended this meeting, so we decided to postpone it.

Since only two showed up, I think it's time to review the meeting time again.

Please tell us if the suggested meeting date & time is ok with you! We've delayed the start time 1 hour, to see if more will attend. If this is fine, then accept it.

If the proposed time doesn't work for you, but you would like to suggest another time, then tell us in the PR comments.

If you can't (or won't) come no matter the time or day, then please remove yourself as a reviewer (or have one of us remove you).

Thank you! :-)