### PR TITLE
Mention licenses of software policies

### DIFF
--- a/docs/guides/security-policy-for-authors.md
+++ b/docs/guides/security-policy-for-authors.md
@@ -454,6 +454,8 @@ Please see the software documentation for further information.
 
 You may use, modify and share this file under the terms of the [CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/deed) license.
 
+The actual security policies written based on this guide, including any recommended wording or example policies, are in the [public domain](https://creativecommons.org/public-domain/cc0/).
+(This includes any policies based on prior versions of this guide.)
 
 ### Acknowledgements
 


### PR DESCRIPTION
This is in response to https://github.com/robrwo/Data-Float/issues/3 where someone had a concern about `SECURITY.md` violating CC4 because the guide was licensed under CC4.