### PR TITLE
Change 'Github' to 'GitHub', part 2

### DIFF
--- a/_posts/2024-02-10-vulnerable-spreadsheet-parsing-modules.md
+++ b/_posts/2024-02-10-vulnerable-spreadsheet-parsing-modules.md
@@ -62,7 +62,7 @@ On November 17th, Đình Hải Lê attempted to contact the last maintainer to r
 
 Unfortunately neither contact attempt succeeded.
 
-On March 15th, the Initial PoC was published on Github by Đình Hải Lê.
+On March 15th, the Initial PoC was published on GitHub by Đình Hải Lê.
 
 On June 20th, Đình Hải Lê submitted both bugs to huntr.com.
 huntr.com supports an open source vulnerability disclosure program, where any member of the public can report vulnerabilities found in repositories on GitHub.com.

--- a/meetings/cpansec-minutes-2025-01-08.md
+++ b/meetings/cpansec-minutes-2025-01-08.md
@@ -93,7 +93,7 @@ title: Minutes 2025-01-08
   - [Issue raised in MetaCPAN](https://github.com/metacpan/metacpan-web/issues/3246) to highlight the document like it does README, LICENSE etc
   - Most important: we are getting feedback
 - @tux - Software::Security::Policy::Individual - do we need ::Team (or other name)?
-  - team policies to be documented: active teams, active groups, active Github projects with more maintainers but no single person to address for vulnerabilities (hidden Github security issues)
+  - team policies to be documented: active teams, active groups, active GitHub projects with more maintainers but no single person to address for vulnerabilities (hidden GitHub security issues)
   - discussed also different ideas about how templates will evolve.
 
 ### CPAN Meta Spec, Requirements and PURLs
@@ -107,7 +107,7 @@ title: Minutes 2025-01-08
 - @sjn - finishing work on NIS2 consultation tonight; Deadline Jan 9th
 
 ### Eclipse ORC WG
-- @sjn - moved org to Github, set up a Slack server for comms.
+- @sjn - moved org to GitHub, set up a Slack server for comms.
 
 ### CycloneDX 1.7 Sustainability fields
 - @sjn - moving forward with the Project needs enumeration; Latest addition: mental health first aider.

--- a/meetings/cpansec-minutes-2025-03-12.md
+++ b/meetings/cpansec-minutes-2025-03-12.md
@@ -204,8 +204,8 @@ title: CPANSec bi-weekly minutes
 - @sjn - investigates alternatives
    - [x] @sjn - Cryptpad investigated, and not usable for calendar stuff. [New calendar URL set up directly in google calendar](https://calendar.google.com/calendar/u/0/embed?src=691584e3db7d0a877b43482fc996eaae9984cf8ba0b769d5d00d042a32f9c66e@group.calendar.google.com) by @sjn, and added to the meetings page.
    - [x] @sjn - New Mastodon account created on https://fosstodon.org/@cpansec - please subscribe!
-- [x] @sjn - Create a list of common/shared CPANSec resources & contact points/people to a private repo on Github.
-   - @sjn - Done; Please check it out (look for it on Github), and help keep it correct and up-to-date!
+- [x] @sjn - Create a list of common/shared CPANSec resources & contact points/people to a private repo on GitHub.
+   - @sjn - Done; Please check it out (look for it on GitHub), and help keep it correct and up-to-date!
 
 
 ## Next meeting date, time and location

--- a/notes/test.md
+++ b/notes/test.md
@@ -111,7 +111,7 @@ example.
 
 ----
 
-## Github variables
+## GitHub variables
 
 Found on https://jekyll.github.io/github-metadata/site.github/
 


### PR DESCRIPTION
Part 2 of PR #150. Trivial corrections to various files. "GitHub" is the correct way to write the name of this website.

I left the `Gemfile` alone. Editing that made me nervous and seemed unnecessary anyway.