### PR TITLE
Add mention of public credit

### DIFF
--- a/docs/guides/security-policy-for-authors.md
+++ b/docs/guides/security-policy-for-authors.md
@@ -179,6 +179,12 @@ Add a reminder to include details for verifying the bug:
 > report does not expose any sensitive data, such as passwords,
 > tokens, or personal information.
 
+It is worth reminding users that they may be credited publicly:
+
+> Project maintainers will normally credit the reporter when a
+> vulnerability is disclosed or fixed.  If you do not want to be
+> credited publicly, please indicate that in your report.
+
 We recommend that you add note about also copying CPANSec on the
 notification if help is required triaging the issue, or if the issue
 is being actively exploited.  CPANSec provides support to reporters
@@ -406,6 +412,10 @@ Please include as many details as possible, including code samples
 or test cases, so that we can reproduce the issue.  Check that your
 report does not expose any sensitive data, such as passwords,
 tokens, or personal information.
+
+Project maintainers will normally credit the reporter when a
+vulnerability is disclosed or fixed.  If you do not want to be
+credited publicly, please indicate that in your report.
 
 If you would like any help with triaging the issue, or if the issue
 is being actively exploited, please copy the report to the CPAN

--- a/docs/guides/security-policy-for-authors.md
+++ b/docs/guides/security-policy-for-authors.md
@@ -119,7 +119,7 @@ If your security policy is based on the advice of this document, then
 you should mention that, along with the version:
 
 > This text is based on the CPAN Security Group's Guidelines for Adding
-> a Security Policy to Perl Distributions (version 1.3.0)
+> a Security Policy to Perl Distributions (version 1.3.1)
 > https://security.metacpan.org/docs/guides/security-policy-for-authors.html
 
 #### Links from other module documentation
@@ -400,7 +400,7 @@ The latest version of the Security Policy can be found in the
 [git repository for Foo-Bar](https://example.github.com/foobar).
 
 This text is based on the CPAN Security Group's Guidelines for Adding
-a Security Policy to Perl Distributions (version 1.3.0)
+a Security Policy to Perl Distributions (version 1.3.1)
 https://security.metacpan.org/docs/guides/security-policy-for-authors.html
 
 # How to Report a Security Vulnerability
@@ -510,7 +510,7 @@ Please see the software documentation for further information.
 
 ## License and use of this document
 
-* Version: 1.3.0
+* Version: 1.3.1
 * License: [CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/deed)
 * Copyright: © Robert Rothenberg <rrwo@cpan.org>, Some rights reserved.
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -57,6 +57,7 @@ Please ensure any sensitive data such as passwords, authentication tokens, or pe
 
 Also consider proposing a date for public disclosure, this is usually 30 days or longer.
 
+If you do not want to be publicly credited as the reporter of the vulnerability, then you should indicate that in your report.
 
 ### Step 2: Contact the Maintainer
 


### PR DESCRIPTION
The question of whether to credit reporters publicly came up. This change adds a reminder for people who do not want to be credited publicly.