### PR TITLE
Fix stale Updated date on pages

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -33,6 +33,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so jekyll-last-modified-at can read each file's
+          # last commit date rather than the build date
+          fetch-depth: 0
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :jekyll_plugins do
   gem "jekyll-mermaid", ">= 1"
   gem "jekyll-include-cache"
   gem "jekyll-gfm-admonitions"
+  gem "jekyll-last-modified-at"
 #  gem 'jekyll-optional-front-matter'
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -180,6 +180,7 @@ plugins:
   - jekyll-titles-from-headings
   - jekyll-include-cache
   - jekyll-gfm-admonitions
+  - jekyll-last-modified-at
 #  - jekyll-optional-front-matter
 
 # Exclude from processing.


### PR DESCRIPTION
## Summary

The "Updated:" date in the page footer fell back to the static `date` field in each page's front matter, so it never changed when a page's content was edited. For example `docs/cna-faq.html` showed January 2025 despite later edits. This enables the `jekyll-last-modified-at` plugin so the footer date is derived from git history instead.

## Changes

- Add `jekyll-last-modified-at` to the `Gemfile` and the `_config.yml` plugins list. It populates `page.last_modified_at`, which the existing `_includes/page__date.html` footer already prefers over the static `date`.
- Fetch full git history in the Pages build workflow (`fetch-depth: 0`) so the plugin reads each file's last-commit date rather than the build date.

## Implications

- The footer "Updated:" date now reflects the last commit that touched each page. The top-of-page "published" date (`page.date`) is intentionally left unchanged.
- The site already builds with `bundle exec jekyll build` via Actions (not the restricted GitHub Pages builder), so this non-allowlisted plugin works.
- Verified locally with a Ruby 3.1 build: the `docs/cna-faq.html` footer now shows the real last-commit date.